### PR TITLE
Removing duplicated `help` option on CLI page.

### DIFF
--- a/commandline.html
+++ b/commandline.html
@@ -9,19 +9,19 @@ The Yeoman Command-Line Interface (CLI) provides access to most of our features.
 
 ## Commands & Topics
 
-* [build](#build)
-* [generator](#generator)
 * [help](#help)
 * [init](#init)
-* [install](#install)
-* [list](#list)
-* [lookup](#lookup)
-* [modules](#modules)
-* [search](#search)
+* [build](#build)
 * [server](#server)
 * [test](#test)
-* [uninstall](#uninstall)
+* [generator](#generator)
+* [modules](#modules)
+* [install](#install)
 * [update](#update)
+* [search](#search)
+* [list](#list)
+* [lookup](#lookup)
+* [uninstall](#uninstall)
 
 {% include yeoman/docs/cli/commands/help.md %}
 {% include yeoman/docs/cli/commands/init.md %}


### PR DESCRIPTION
Also, now listing options on alphabetical order
