### PR TITLE
Github pages doesn't support ssl so this is pointless

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,7 +60,7 @@
       ['_setDomainName', '.yeoman.io'],
       ['_trackPageview'],['_trackPageLoadTime']
     ];
-    $script(('https:'==location.protocol?'//ssl':'http://www')+'.google-analytics.com/ga.js');
+    $script('http://www.google-analytics.com/ga.js');
     $script('https://apis.google.com/js/plusone.js');
     $script("//platform.twitter.com/widgets.js");
   </script>


### PR DESCRIPTION
This is a really tiny change and I know it goes against the recommended GA practice but this always bother me in GH Pages being that (as far as I know) GH Pages doesn't support ssl traffic so the ternary is really pointless.
