### PR TITLE
Changed Generators github repository.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,7 +43,7 @@
       </section>
       <section class="repo">
         <h2>Generators</h2>
-        <a href="https://github.com/yeoman/generators">
+        <a href="https://github.com/yeoman/generator">
           <img src="assets/img/yeoman-005.png" class="character">
         </a>
         <p>Rails-like generator system for Yeoman that provide scaffolding for your apps</p>


### PR DESCRIPTION
Generators repository changed, form "https://github.com/yeoman/generators" to "https://github.com/yeoman/generator", but page still points to old one. 
