### PR TITLE
Fix path to Getting Started page.

### DIFF
--- a/gettingstarted_1.0.html
+++ b/gettingstarted_1.0.html
@@ -3,4 +3,4 @@ layout: default
 markdown: 1
 ---
 
-{% include yeoman.wiki/Getting-started-with-1.0.md %}
+{% include yeoman.wiki/Getting-started-with-1.0-beta.md %}


### PR DESCRIPTION
The page http://yeoman.io/gettingstarted_1.0.html currently displays `Included file 'yeoman.wiki/Getting-started-with-1.0.md' not found in _includes directory`
