### PR TITLE
Clean up jekyll layout

### DIFF
--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -1,0 +1,13 @@
+<script>
+  // $script.js - github.com/ded/script.js
+  (function(a,b,c){typeof c["module"]!="undefined"&&c.module.exports?c.module.exports=b():typeof c["define"]!="undefined"&&c["define"]=="function"&&c.define.amd?define(a,b):c[a]=b()})("$script",function(){function p(a,b){for(var c=0,d=a.length;c<d;++c)if(!b(a[c]))return j;return 1}function q(a,b){p(a,function(a){return!b(a)})}function r(a,b,i){function o(a){return a.call?a():d[a]}function t(){if(!--n){d[m]=1,l&&l();for(var a in f)p(a.split("|"),o)&&!q(f[a],o)&&(f[a]=[])}}a=a[k]?a:[a];var j=b&&b.call,l=j?b:i,m=j?a.join(""):b,n=a.length;return setTimeout(function(){q(a,function(a){if(h[a])return m&&(e[m]=1),h[a]==2&&t();h[a]=1,m&&(e[m]=1),s(!c.test(a)&&g?g+a+".js":a,t)})},0),r}function s(c,d){var e=a.createElement("script"),f=j;e.onload=e.onerror=e[o]=function(){if(e[m]&&!/^c|loade/.test(e[m])||f)return;e.onload=e[o]=null,f=1,h[c]=2,d()},e.async=1,e.src=c,b.insertBefore(e,b.firstChild)}var a=document,b=a.getElementsByTagName("head")[0],c=/^https?:\/\//,d={},e={},f={},g,h={},i="string",j=!1,k="push",l="DOMContentLoaded",m="readyState",n="addEventListener",o="onreadystatechange";return!a[m]&&a[n]&&(a[n](l,function t(){a.removeEventListener(l,t,j),a[m]="complete"},j),a[m]="loading"),r.get=s,r.order=function(a,b,c){(function d(e){e=a.shift(),a.length?r(e,d):r(e,b,c)})()},r.path=function(a){g=a},r.ready=function(a,b,c){a=a[k]?a:[a];var e=[];return!q(a,function(a){d[a]||e[k](a)})&&p(a,function(a){return d[a]})?b():!function(a){f[a]=f[a]||[],f[a][k](b),c&&c(e)}(a.join("|")),r},r},this)
+  var _gaq=[
+    ['_setAccount','UA-32956520-1'],
+    ['_setDomainName', '.yeoman.io'],
+    ['_trackPageview'],['_trackPageLoadTime']
+  ];
+  $script('http://www.google-analytics.com/ga.js');
+  $script('https://apis.google.com/js/plusone.js');
+  $script("//platform.twitter.com/widgets.js");
+</script>
+<script src="assets/js/libs/forkit.js"></script>

--- a/_includes/forkit.html
+++ b/_includes/forkit.html
@@ -1,0 +1,28 @@
+<div class="forkit-curtain">
+  <div class="close-button"></div>
+    <h2>Yeoman Repositories</h2>
+    <section class="repo">
+      <h2>Yeoman</h2>
+      <a href="https://github.com/yeoman/yeoman">
+        <img src="assets/img/yeoman-003.png" class="character">
+      </a>
+      <p>Your new favorite web application stack and development tool</p>
+    </section>
+    <section class="repo">
+      <h2>Yeoman.io</h2>
+      <a href="https://github.com/yeoman/yeoman.io">
+        <img src="assets/img/yeoman-007.png" class="character">
+      </a>
+      <p>Yeoman website</p>
+    </section>
+    <section class="repo">
+      <h2>Generators</h2>
+      <a href="https://github.com/yeoman/generator">
+        <img src="assets/img/yeoman-005.png" class="character">
+      </a>
+      <p>Rails-like generator system for Yeoman that provide scaffolding for your apps</p>
+    </section>
+</div>
+<a class="forkit" data-text="Fork me on GitHub" data-text-detached="Drag down >" href="https://github.com/yeoman">
+  <img class="forkit-img" src="https://a248.e.akamai.net/camo.github.com/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub">
+</a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,13 @@
+<head>
+  <meta charset="utf-8">
+  <title>Yeoman - Modern workflows for modern webapps</title>
+  <meta name="viewport" content="width=device-width">
+  <link href="http://fonts.googleapis.com/css?family=Droid+Sans|Lekton|Ubuntu+Mono:400,700" rel="stylesheet">
+  <link href="assets/css/normalize.css" rel="stylesheet">
+  <link href="assets/css/yeoman.css" rel="stylesheet">
+  <link href="assets/css/prettify.css" rel="stylesheet">
+  <link href="assets/css/forkit.css" rel="stylesheet">
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script src="assets/js/libs/prettify.js"></script>
+  <script src="assets/js/script.js"></script>
+</head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,18 +1,6 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Yeoman - Modern workflows for modern webapps</title>
-  <meta name="viewport" content="width=device-width">
-  <link href="http://fonts.googleapis.com/css?family=Droid+Sans|Lekton|Ubuntu+Mono:400,700" rel="stylesheet">
-  <link href="assets/css/normalize.css" rel="stylesheet">
-  <link href="assets/css/yeoman.css" rel="stylesheet">
-  <link href="assets/css/prettify.css" rel="stylesheet">
-  <link href="assets/css/forkit.css" rel="stylesheet">
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-  <script src="assets/js/libs/prettify.js"></script>
-  <script src="assets/js/script.js"></script>
-</head>
+{% include head.html %}
 <body>
   {% include sidebar.html %}
   <div id="content">
@@ -25,47 +13,8 @@
     </article>
   </div>
 <!--
-  <div class="forkit-curtain">
-    <div class="close-button"></div>
-      <h2>Yeoman Repositories</h2>
-      <section class="repo">
-        <h2>Yeoman</h2>
-        <a href="https://github.com/yeoman/yeoman">
-          <img src="assets/img/yeoman-003.png" class="character">
-        </a>
-        <p>Your new favorite web application stack and development tool</p>
-      </section>
-      <section class="repo">
-        <h2>Yeoman.io</h2>
-        <a href="https://github.com/yeoman/yeoman.io">
-          <img src="assets/img/yeoman-007.png" class="character">
-        </a>
-        <p>Yeoman website</p>
-      </section>
-      <section class="repo">
-        <h2>Generators</h2>
-        <a href="https://github.com/yeoman/generator">
-          <img src="assets/img/yeoman-005.png" class="character">
-        </a>
-        <p>Rails-like generator system for Yeoman that provide scaffolding for your apps</p>
-      </section>
-  </div>
-  <a class="forkit" data-text="Fork me on GitHub" data-text-detached="Drag down >" href="https://github.com/yeoman">
-    <img class="forkit-img" src="https://a248.e.akamai.net/camo.github.com/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub">
-  </a>
+  {% include forkit.html %}
 -->
-  <script>
-    // $script.js - github.com/ded/script.js
-    (function(a,b,c){typeof c["module"]!="undefined"&&c.module.exports?c.module.exports=b():typeof c["define"]!="undefined"&&c["define"]=="function"&&c.define.amd?define(a,b):c[a]=b()})("$script",function(){function p(a,b){for(var c=0,d=a.length;c<d;++c)if(!b(a[c]))return j;return 1}function q(a,b){p(a,function(a){return!b(a)})}function r(a,b,i){function o(a){return a.call?a():d[a]}function t(){if(!--n){d[m]=1,l&&l();for(var a in f)p(a.split("|"),o)&&!q(f[a],o)&&(f[a]=[])}}a=a[k]?a:[a];var j=b&&b.call,l=j?b:i,m=j?a.join(""):b,n=a.length;return setTimeout(function(){q(a,function(a){if(h[a])return m&&(e[m]=1),h[a]==2&&t();h[a]=1,m&&(e[m]=1),s(!c.test(a)&&g?g+a+".js":a,t)})},0),r}function s(c,d){var e=a.createElement("script"),f=j;e.onload=e.onerror=e[o]=function(){if(e[m]&&!/^c|loade/.test(e[m])||f)return;e.onload=e[o]=null,f=1,h[c]=2,d()},e.async=1,e.src=c,b.insertBefore(e,b.firstChild)}var a=document,b=a.getElementsByTagName("head")[0],c=/^https?:\/\//,d={},e={},f={},g,h={},i="string",j=!1,k="push",l="DOMContentLoaded",m="readyState",n="addEventListener",o="onreadystatechange";return!a[m]&&a[n]&&(a[n](l,function t(){a.removeEventListener(l,t,j),a[m]="complete"},j),a[m]="loading"),r.get=s,r.order=function(a,b,c){(function d(e){e=a.shift(),a.length?r(e,d):r(e,b,c)})()},r.path=function(a){g=a},r.ready=function(a,b,c){a=a[k]?a:[a];var e=[];return!q(a,function(a){d[a]||e[k](a)})&&p(a,function(a){return d[a]})?b():!function(a){f[a]=f[a]||[],f[a][k](b),c&&c(e)}(a.join("|")),r},r},this)
-    var _gaq=[
-      ['_setAccount','UA-32956520-1'],
-      ['_setDomainName', '.yeoman.io'],
-      ['_trackPageview'],['_trackPageLoadTime']
-    ];
-    $script('http://www.google-analytics.com/ga.js');
-    $script('https://apis.google.com/js/plusone.js');
-    $script("//platform.twitter.com/widgets.js");
-  </script>
-  <script src="assets/js/libs/forkit.js"></script>
+{% include foot.html %}
 </body>
 </html>


### PR DESCRIPTION
Cleaned up the default layout used on the website and moved the head and foot(er) to separate includes files to make it easier to edit and expand layouts later if needed. 

This will make it easier to redesign the site for release of v1.0 while keeping the same "back-end" model of jekyll and wiki module.
