### PR TITLE
Use https version of yeoman-generator-list

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -35,7 +35,7 @@ var setMenuBackgroundHeight = function() {
   'use strict';
 
   $(function () {
-    $.getJSON('http://yeoman-generator-list.herokuapp.com', function (modules) {
+    $.getJSON('https://yeoman-generator-list.herokuapp.com', function (modules) {
 
       var blocklist = [
         'generator-express-angular', // haven't updated package.json


### PR DESCRIPTION
Currently the page doesn't work with the very popular [https everywhere](https://chrome.google.com/webstore/detail/https-everywhere/gcbommkclmclpchllfjekcdonpmejbdp) extension, by linking directly to the https version this will no longer be a problem.
