### PR TITLE
Remove stray closing brace in CSS

### DIFF
--- a/assets/css/yeoman.css
+++ b/assets/css/yeoman.css
@@ -601,6 +601,3 @@ pre{
     display: table-cell;
   }
 }
-
-}
-


### PR DESCRIPTION
While getting Usemin to parse CSS, found some stray closing braces. 

Yeoman.io, now with less }'s!
