### PR TITLE
allow the use of draft posts.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -170,6 +170,13 @@ module.exports = function (grunt) {
           dest: '.jekyll'
         }
       },
+      draft: {
+        options: {
+          config: '_config.yml',
+          dest: '.jekyll',
+          drafts: true
+        }
+      },
       check: {
         options: {
           doctor: true
@@ -327,6 +334,11 @@ module.exports = function (grunt) {
         'copy:stageCss',
         'jekyll:server'
       ],
+      draft: [
+        'sass:server',
+        'copy:stageCss',
+        'jekyll:draft'
+      ],
       dist: [
         'sass:dist',
         'copy:dist'
@@ -340,9 +352,11 @@ module.exports = function (grunt) {
       return grunt.task.run(['default', 'connect:dist:keepalive']);
     }
 
+    target = target || 'server';
+
     grunt.task.run([
       'clean:server',
-      'concurrent:server',
+      'concurrent:' + target,
       'autoprefixer:server',
       'connect:livereload',
       'watch'

--- a/app/_drafts/angular-generator-testing.md
+++ b/app/_drafts/angular-generator-testing.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: Angular Generator Testing Redone
+---
+


### PR DESCRIPTION
Use `grunt serve:draft` to see the draft posts rendered. Drafts should
go in `app/_drafts`. They can have normal file names. When they are
ready to be published, move them to `app/_posts` with a time-postname
filename format
