### PR TITLE
add sort indicators to generators pages

### DIFF
--- a/app/assets/css/yeoman.css
+++ b/app/assets/css/yeoman.css
@@ -371,6 +371,28 @@ pre{
 .sort {
   text-align: left;
 }
+th.sort:before {
+  color: #999;
+  content: '\21C5';
+  display: inline-block;
+  font-size: 10px;
+  opacity: .6;
+  text-align: center;
+  vertical-align: middle;
+  width: 10px;
+}
+th.sort.asc:before{
+  color: #333;
+  content: '\2193';
+  opacity: 1;
+  text-align: left;
+}
+th.sort.desc:before{
+  color: #333;
+  content: '\2191';
+  opacity: 1;
+  text-align: right;
+}
 
 .icon-white {                       background-image: url("/assets/img/glyphicons-halflings-white.png"); }
 .icon-glass {                       background-position: 0      0; }

--- a/app/community-generators.html
+++ b/app/community-generators.html
@@ -22,9 +22,9 @@ class: discovery-page community-generators
           <th class="sort" data-sort="name">Name</th>
           <th class="sort" data-sort="desc">Description</th>
           <th class="sort" data-sort="author">Author</th>
-          <th class="sort asc" data-sort="updated">Last updated</th>
-          <th class="sort asc" data-sort="stars">Stars</th>
-          <th class="sort asc" data-sort="forks">Forks</th>
+          <th class="sort" data-sort="updated">Last updated</th>
+          <th class="sort" data-sort="stars">Stars</th>
+          <th class="sort" data-sort="forks">Forks</th>
         </tr>
       </thead>
       <tbody class="list">

--- a/app/official-generators.html
+++ b/app/official-generators.html
@@ -19,9 +19,9 @@ class: discovery-page official-generators
         <tr>
           <th class="sort" data-sort="name">Name</th>
           <th class="sort" data-sort="desc">Description</th>
-          <th class="sort asc" data-sort="updated">Last updated</th>
-          <th class="sort asc" data-sort="stars">Stars</th>
-          <th class="sort asc" data-sort="forks">Forks</th>
+          <th class="sort" data-sort="updated">Last updated</th>
+          <th class="sort" data-sort="stars">Stars</th>
+          <th class="sort" data-sort="forks">Forks</th>
         </tr>
       </thead>
       <tbody class="list">


### PR DESCRIPTION
when a header is clicked, an icon will show which sort it is doing. by default it doesnt show any sort going on. 
[preview](https://www.evernote.com/shard/s18/sh/b6943fa1-c2a3-47b3-9060-12aa47e01993/d1b1d6cf146731ff7ba0ba29c764d98d)
