### PR TITLE
Adding missing form-control class to make result consistent with tutorial screenshot

### DIFF
--- a/app/_includes/yeoman.wiki/docs/Codelab.md
+++ b/app/_includes/yeoman.wiki/docs/Codelab.md
@@ -285,7 +285,7 @@ Then modify our view (views/main.html) to output our todos items as text input f
 <div class="container">
   <h2>My todos</h2>
   <p class="form-group” ng-repeat="todo in todos">
-    <input type="text" ng-model="todo">
+    <input type="text" ng-model="todo" class="form-control">
   </p>
 </div>
 


### PR DESCRIPTION
In the codelab, we have the following screenshot for the inital div
![image](https://f.cloud.github.com/assets/1711792/2236370/0b217464-9b5c-11e3-9606-b78ff36fee4e.png)

And we expect it to be rendered as the following:
![image](https://f.cloud.github.com/assets/1711792/2236375/31b567b6-9b5c-11e3-8e60-d32e89ed228e.png)

However in reality, it renders as:
![image](https://f.cloud.github.com/assets/1711792/2236377/44434db2-9b5c-11e3-9df6-788f4f72a63a.png)

It's just a simple matter of adding the 'form-control' class as per commit (also keeps it consistent with the screenshot that follows that section)
