### PR TITLE
Fixed closing html comment tag

### DIFF
--- a/app/_includes/yeoman.wiki/docs/Codelab.md
+++ b/app/_includes/yeoman.wiki/docs/Codelab.md
@@ -515,7 +515,7 @@ Second, add the AngularUI and jQueryUI JavaScript. In the scripts section at the
 ```
   
 
-Note: Make sure to place the reference to angular-ui.js outside of the <!-- bower:js → block as this will otherwise not build correctly due to an issue with the AngularUI Bower package setup.
+Note: Make sure to place the reference to angular-ui.js outside of the `<!-- bower:js -->` block as this will otherwise not build correctly due to an issue with the AngularUI Bower package setup.
 
 Third, load the AngularUI module into our application by updating our Angular module definition in scripts/app.js. Currently it looks like this:
 


### PR DESCRIPTION
Originally an arrow symbol was rendered:
![image](https://f.cloud.github.com/assets/1711792/2236876/85687150-9b70-11e3-97bd-0a6f95853288.png)

Changed to be the correct html comment closing tag and putting it all under code block:
![image](https://f.cloud.github.com/assets/1711792/2236880/9183309c-9b70-11e3-859b-cdeab003e3e7.png)
