### PR TITLE
update bower-install syntax

### DIFF
--- a/app/gettingstarted.md
+++ b/app/gettingstarted.md
@@ -153,13 +153,13 @@ grunt bower
 > Injects your Bower dependencies into your RequireJS configuration.
 
 # If you're not using RequireJS...
-grunt bower-install
+grunt bowerInstall
 > Injects your dependencies into your index.html file.
 ```
 
 It’s as simple as that.
 
-*Your chosen generator may not include the grunt tasks "bower" and "bower-install". You can read more about how to install and use these at [grunt-bower-requirejs](https://github.com/yeoman/grunt-bower-requirejs) and [grunt-bower-install](https://github.com/stephenplusplus/grunt-bower-install).*
+*Your chosen generator may not include the grunt tasks "bower" and "bowerInstall". You can read more about how to install and use these at [grunt-bower-requirejs](https://github.com/yeoman/grunt-bower-requirejs) and [grunt-bower-install](https://github.com/stephenplusplus/grunt-bower-install).*
 
 
 ## Grunt


### PR DESCRIPTION
Not sure exactly when it happened, but it appears that grunt-bower-install has changed its install syntax to `bowerInstall`

https://github.com/stephenplusplus/grunt-bower-install
