### PR TITLE
Add how to contribute guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 node_modules
 app/bower_components
-_site
 dist
 .jekyll
 .tmp
-
 .DS_Store

--- a/app/_includes/sidebar.html
+++ b/app/_includes/sidebar.html
@@ -28,6 +28,11 @@
 
       <li class="nav-divider"><a href="/faq.html"><img src="/assets/img/icon-faqs.png">FAQ</a></li>
 
+      <li class="nav-divider"><a href="/contributing/contributing.html">Contributing</a></li>
+      <li class="nav-sub"><a href="/contributing/opening-issues.html">Opening an issue</a></li>
+      <li class="nav-sub"><a href="/contributing/style-guide.html">Style guide</a></li>
+      <li class="nav-sub"><a href="/contributing/testing-guidelines.html">Testing guidelines</a></li>
+
       <li class="nav-divider"><a href="https://plus.google.com/101063139999404044459/posts"><img src="/assets/img/icon-google-plus.png">Google&#43;</a></li>
       <li><a href="http://twitter.com/yeoman"><img src="/assets/img/icon-twitter.png">Twitter</a></li>
       <li><a href="http://github.com/yeoman/yeoman"><img src="/assets/img/icon-github.png">GitHub</a></li>

--- a/app/contributing/contributing.md
+++ b/app/contributing/contributing.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Contributing
+category: contributing
+excerpt: The yeoman project contribution guidelines
+---
+
+# Contributing
+
+We are more than happy to accept external contributions to the project in the form of feedback, bug reports and even better - pull requests :) At this time we are primarily focusing on improving the user-experience and stability of Yeoman for our first release. Please keep this in mind if submitting feature requests, which we're happy to consider for future versions.
+
+## Pull Request Guidelines
+
+* Please check to make sure that there aren't existing pull requests attempting to address the issue mentioned. We also recommend checking for issues related to the issue on the tracker, as a team member may be working on the issue in a branch or fork.
+* Non-trivial changes should be discussed in an issue first
+* Develop in a topic branch, not master
+* Lint the code by running `grunt` or `gulp`
+* Add relevant tests to cover the change
+* Make sure test-suite passes: `npm test`
+* Squash your commits
+* Write a convincing description of your PR and why we should land it

--- a/app/contributing/opening-issues.md
+++ b/app/contributing/opening-issues.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Opening an issue
+category: contributing
+excerpt: Guidelines to opening an issue on the Yeoman project
+---
+
+# How to open an helpful issue
+
+In order for us to help you please check that you've completed the following steps:
+
+* Made sure you're on the latest version `npm update -g yo`
+* Used the search feature to ensure that the bug hasn't been reported before
+* Included as much information about the bug as possible, including any output you've received, what OS and version you're on, etc.
+* Shared the output from running the following command in your project root as this can also help track down the issue.
+
+Unix:
+
+```
+yo --version && echo $PATH $NODE_PATH && node -e 'console.log(process.platform, process.versions)' && cat Gruntfile.js
+```
+
+Windows:
+
+```
+yo --version && echo %PATH% %NODE_PATH% && node -e "console.log(process.platform, process.versions)" && type Gruntfile.js
+```
+
+Then submit your issue on the relevant repository
+
+* [General concerns on the project](https://github.com/yeoman/yeoman/issues/new)
+* [Issues with `yo`](https://github.com/yeoman/yo/issues/new)
+* [Issues when writing a generator](https://github.com/yeoman/generator/issues/new)
+
+For any issues related to a particular generator (`grunt build` not working, you'd like a new feature, etc), then search on github for the relevant repository. They're usually named `generator-X`.

--- a/app/contributing/style-guide.md
+++ b/app/contributing/style-guide.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Style guide
+category: contributing
+excerpt: The yeoman project style guide
+---
+
+# Style guide
+
+This project uses single-quotes, two space indentation, multiple var statements and whitespace around arguments. Use a single space after keywords like `function`. Ex:
+
+``` js
+function () { ... }
+function foo() { ... }
+```
+
+Please ensure any pull requests follow this closely. If you notice existing code which doesn't follow these practices, feel free to shout and we will address this.

--- a/app/contributing/testing-guidelines.md
+++ b/app/contributing/testing-guidelines.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: Testing Guidelines
+category: contributing
+excerpt: The yeoman project unit testing guidelines
+---
+
+Yeoman Testing Guidelines
+====================
+
+This testing guide is based on Mocha BDD interface (`describe` / `it`).
+
+
+Main principles
+--------------------
+
+#### Tests must be always start with a clean state
+
+This means prefer `beforeEach` to `before`. Re-instantiate objects before running each `it` blocks. Create every files required by a test in a `beforeEach` (or commit them in `fixtures/`). Reset any side effets done on the test environment after each test.
+
+#### Tests must be runnable in isolation
+
+Each test must pass if they're runned alone. You can run a single test by using `mocha test.js --grep 'test name'`.
+
+#### Stub most performance heavy operation
+
+When possible, always stub networks or other long operations.
+
+We use [sinon.js](http://sinonjs.org/) for most stubbing needs.
+
+Naming convention
+--------------------
+
+`describe` blocks should cover three types of information: Object to be tested, method/property, circumstantial group (basically, "when _this_").
+
+`it` blocks cover assertions. They should use as few lines of code as possible. There should be as many `it` block as there is assertion on a method effect.
+
+Instances methods and property should be prefixed by a bang sign (`#find()`). Static methods and property should be prefixed by a dot (`.exclude()`).
+
+```javascript
+// Given this object
+function Class() {
+  this.args = nopt();
+};
+Class.exclude = function () {};
+Class.name = 'Yeoman';
+Class.prototype.find = function () {};
+
+// We'd had this test structure
+describe('Class', function () {
+  describe('.exclude()', function () {});
+  describe('.name', function () {});
+  describe('#find()', function () {});
+  describe('#args', function () {});
+});
+```
+
+Methods should end using parentheses, but should not include expected parameters (parameters should be cover in documentation comments).
+
+`it` blocks should be declarative.
+
+```javascript
+// BAD
+it('should find generators');
+
+// GOOD
+it('find generators');
+```
+
+Assertion
+---------------------
+
+Don't add `message` to assertions unless the error thrown makes it unclear what failed.
+
+If you must add a message, then describe the expected outcome and why it failed. For example:
+
+``` javascript
+// BAD
+assert(Generator.appname, 'Generator have an `appname` property');
+
+// GOOD
+assert(Generator.appname, 'Expected Generator to have an `appname` property');
+```
+
+Remember that these message are the error message thrown with the failure. Let those be useful in these occasions.
+
+Stylistic preferences
+----------------------
+
+#### `.bind()` throwing assertions
+
+When testing that a method throw with invalid parameters, prefer binding the parameters to creating an anonymous function.
+
+```javascript
+// BAD
+assert.throws(function () {
+  class.method('Invalid param');
+});
+
+// GOOD
+assert.throws(class.method.bind(class, 'Invalid param'));
+```


### PR DESCRIPTION
Some could be more detailed in the future, but I based myself on the current contributing.md file in the yeoman repo.

I also removed any reference to the CLA as we never really used it.
