### PR TITLE
Prevent long nav items from breaking out of container

### DIFF
--- a/app/assets/css/yeoman.css
+++ b/app/assets/css/yeoman.css
@@ -142,7 +142,6 @@ nav ul {
 }
 
 nav ul li {
-  white-space: nowrap;
   line-height: 21px;
   padding-top: 2px;
   padding-bottom: 2px;
@@ -286,7 +285,7 @@ article p {
 
 pre{
   font-size: 13px;
-  padding: 2px; border: 1px solid #ccc;
+  border: 1px solid #ccc;
   background-color: #000;
   color: #ccc;
   border-radius: 5px;
@@ -580,7 +579,6 @@ th.sort.desc:before{
 
   nav ul li {
     display: inline;
-    white-space: normal;
     margin-right: 10px;
   }
 


### PR DESCRIPTION
Fix for the following problems with long items in navigation menu:
Desktop / wide screen:
![Desktop|wide screen](http://i.imgur.com/8Y1C8P9.png)
Mobile / small screen:
![Mobile|small screen](http://i.imgur.com/8LwNV6L.png)

And small cleaning: double "padding" declaration.
