### PR TITLE
Docs: add a simple usage example for npmInstall

### DIFF
--- a/app/authoring/dependencies.md
+++ b/app/authoring/dependencies.md
@@ -14,6 +14,26 @@ As these tasks are very frequent, Yeoman already abstracts them away. We'll also
 
 You just need to call `generator.npmInstall()` to run an `npm` installation. Yeoman will ensure the `npm install` command is only run once even if it is called multiple time by multiple generators.
 
+For example you want to install lodash as a dev dependency:
+
+```js
+yeoman.generators.Base.extend({
+  installingLodash: function() {
+    var done = this.async();
+    this.npmInstall(['lodash'], { 'saveDev': true }, done);
+  }
+}):
+```
+
+This is aequivalent to call:
+
+```
+npm install lodash --save-dev
+```
+
+on the command line in your project.
+
+
 ## Bower
 
 You just need to call `generator.bowerInstall()` to launch the installation. Yeoman will ensure the `bower install` command is only run once even if it is called multiple time by multiple generators.


### PR DESCRIPTION
Hey guys,

thank you for writing yeoman. When I started to understand how the parameters from npmInstall have to look like, I felt it could need a small usage example in the docu.

Questions:
- should it be called with this.on('end') per default? (is yeoman doing this in the current version automatically?
- should this example be improved in some ways?
- do you need a CLA from me? (I'm totally fine that you use all my contributions)
- may I improve the api docs as well?

best regards
Philipp
