### PR TITLE
fix(event loop): Changed .base to .Base

### DIFF
--- a/app/authoring/running-context.md
+++ b/app/authoring/running-context.md
@@ -22,7 +22,7 @@ Now that you know the prototype methods are considered as action, you may wonder
 2. Use instance methods:
 
   ```js
-    yeoman.generators.base.extend({
+    yeoman.generators.Base.extend({
       init: function () {
         this.helperMethod = function () {
           console.log('won\'t be called automatically');
@@ -33,7 +33,7 @@ Now that you know the prototype methods are considered as action, you may wonder
 3. Extend a parent generator
 
   ```js
-    var MyBase = yeoman.generators.base.extend({
+    var MyBase = yeoman.generators.Base.extend({
       helper: function () {
         console.log('won\'t be called automatically');
       }


### PR DESCRIPTION
Changed two references of `generators.base` to `generators.Base`. Without the change users copying and pasting the example code will get errors.
