### PR TITLE
Fix team at min-width: 35em

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1023,8 +1023,7 @@ Modify as content requires.
   }
 
   .team li {
-    display: block;
-    float: left;
+    display: inline-block;
     width: 30%;
     margin-right: 3%;
     margin-bottom: 2em;


### PR DESCRIPTION
On a very particular window width and given the right (wrong?) font rendering, it can happen that a name floats next to somebody's picture. We could avoid the floaty bits by just making the list elements inline-blocks. Please review in case I'm missing some consequences of this. :)

![screenshot from 2014-07-09 23 03 17](https://cloud.githubusercontent.com/assets/9906/3532246/eca5bb70-07b8-11e4-8301-809d16bcb879.png)
