### PR TITLE
Use implicit dependency injection for local storage example in codelab

### DIFF
--- a/app/codelab/local-storage.md
+++ b/app/codelab/local-storage.md
@@ -78,9 +78,9 @@ angular
 While you’re in *app.js*, also configure `localStorageServiceProvider` to use `"ls"` as a localStorage name prefix so your app doesn’t accidently read todos from another app using the same variable names:
 
 ```js
-.config(['localStorageServiceProvider', function(localStorageServiceProvider){
+.config(function (localStorageServiceProvider) {
   localStorageServiceProvider.setPrefix('ls');
-}])
+})
 ```
 
 Our application module should now look like this:
@@ -99,9 +99,9 @@ angular
     'ui.sortable',
     'LocalStorageModule'
   ])
-  .config(['localStorageServiceProvider', function(localStorageServiceProvider){
+  .config(function (localStorageServiceProvider) {
     localStorageServiceProvider.setPrefix('ls');
-  }])
+  })
   .config(function ($routeProvider) {
     $routeProvider
       .when('/', {


### PR DESCRIPTION
Fixes #270. Building the production ready code after following the instructions for integrating local storage produces an uncaught object error.