### PR TITLE
Menus improvements.

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -222,10 +222,13 @@ Navigation
   display: none;
   position: fixed;
   top: 48px;
+  bottom: 0;
   right: 0;
   left: 0;
   z-index: 10;
-  overflow-y: scroll;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 .open .main-menu {
   display: block;


### PR DESCRIPTION
Hey guys, mobile menu is not scrollable on iOS.

Im not sure if you would like to have page visible only until menu ends, if so, I can do it but there will be needed also little of js. (adding height: calc(100% - 48px) to .main-menu fixes scrolling on position fixed, but its not the greatest experience, and calc don't work on older androids)
