### PR TITLE
Error in the social icons

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1208,7 +1208,11 @@ Modify as content requires.
     text-align: left;
     width: 50%;
   }
-
+  
+  .footer-links-social li {
+    display: inline !important;
+  }
+  
   .footer-links-contribute {
     float: right;
     text-align: right;


### PR DESCRIPTION
This error causes social icons overlap each other, this happens due to the display: inline-block; I've solved it with display: inline; attached a screenshot of the error looks like 

![captura de pantalla - 070914 - 20 19 12](https://cloud.githubusercontent.com/assets/2553459/4180650/68faee32-36ff-11e4-980e-0e9c545871b0.png)
