### PR TITLE
Updated correct path for jquery-ui.js

### DIFF
--- a/app/codelab/install-packages.md
+++ b/app/codelab/install-packages.md
@@ -75,7 +75,7 @@ Quit your current command line process by using the <span class="keyboard">Ctrl<
 
 Then run `grunt serve` again.
 
-You'll see that the `script` section at the bottom of *index.html* has automatically updated to include `jquery-ui/ui/jquery-ui.js` and `angular-ui-sortable/sortable.js`:
+You'll see that the `script` section at the bottom of *index.html* has automatically updated to include `jquery-ui/jquery-ui.js` and `angular-ui-sortable/sortable.js`:
 
 ```html
 <!-- build:js scripts/vendor.js -->
@@ -89,7 +89,7 @@ You'll see that the `script` section at the bottom of *index.html* has automatic
 <script src="bower_components/angular-animate/angular-animate.js"></script>
 <script src="bower_components/angular-touch/angular-touch.js"></script>
 <script src="bower_components/angular-route/angular-route.js"></script>
-<script src="bower_components/jquery-ui/ui/jquery-ui.js"></script>
+<script src="bower_components/jquery-ui/jquery-ui.js"></script>
 <script src="bower_components/angular-ui-sortable/sortable.js"></script>
 <!-- endbower -->
 <!-- endbuild -->


### PR DESCRIPTION
Changed <script src="bower_components/jquery-ui/ui/jquery-ui.js"></script> to <script src="bower_components/jquery-ui/jquery-ui.js"></script> to include jquery-ui.js.
