### PR TITLE
Step 9 -> Step 10

### DIFF
--- a/app/codelab/write-app.md
+++ b/app/codelab/write-app.md
@@ -213,7 +213,7 @@ Back in the browser, you can now hit the **X** button to remove the item from th
   <img src="/assets/img/codelab/image_21.png">
 </div>
 
-One thing you might notice is that we don’t have a way to persist our todo list. Any time we refresh the page our todo items are reset back to the defaults in our `todos` array hardcoded in *main.js*. Don’t worry, we’ll fix this in [Step 9](local-storage.html) after we learn more about installing packages with Bower next in [Step 7](install-packages.html).
+One thing you might notice is that we don’t have a way to persist our todo list. Any time we refresh the page our todo items are reset back to the defaults in our `todos` array hardcoded in *main.js*. Don’t worry, we’ll fix this in [Step 10](local-storage.html) after we learn more about installing packages with Bower next in [Step 7](install-packages.html).
 
 <p class="codelab-paging">
   <a href="../codelab.html#toc">&laquo; Return to overview</a>


### PR DESCRIPTION
Link for skipping forward in the tutorial should be 10 instead of 9, as the tutorial structure seems to have changed and the link description/text hasn't been updated.
