### PR TITLE
Angular Local Storage changes

### DIFF
--- a/app/codelab/local-storage.md
+++ b/app/codelab/local-storage.md
@@ -144,10 +144,10 @@ And replace it with this:
 ```js
 var todosInStore = localStorageService.get('todos');
 
-$scope.todos = todosInStore && todosInStore.split('\n') || [];
+$scope.todos = todosInStore || [];
 
 $scope.$watch('todos', function () {
-  localStorageService.add('todos', $scope.todos.join('\n'));
+  localStorageService.set('todos', $scope.todos);
 }, true);
 ```
 
@@ -161,10 +161,10 @@ angular.module('mytodoApp')
 
     var todosInStore = localStorageService.get('todos');
 
-    $scope.todos = todosInStore && todosInStore.split('\n') || [];
+    $scope.todos = todosInStore || [];
 
     $scope.$watch('todos', function () {
-      localStorageService.add('todos', $scope.todos.join('\n'));
+      localStorageService.set('todos', $scope.todos);
     }, true);
 
     $scope.addTodo = function () {


### PR DESCRIPTION
Method for setting is now `set` instead of `add`.
Object data is stored as JSON and parsed on get.
https://github.com/grevory/angular-local-storage

> add method was deprecated and renamed to set. It also supports storing a JavaScript object (using angular.toJson internally) and retrieving (using angular.fromJson).
> 
> PR #340, sorry for pushing to master.
