### PR TITLE
Update to index.md

### DIFF
--- a/app/learning/index.md
+++ b/app/learning/index.md
@@ -64,6 +64,13 @@ The webapp generator is considered the simplest possible start for a web app. We
 
 #### Example: Scaffolding an AngularJS app
 
+Generating an angular app requires Bower, you must install it from npm first:
+
+```sh
+$ npm install -g bower
+```
+
+
 As always, before using a new generator, you must install it from npm first:
 
 ```sh


### PR DESCRIPTION
if Bower is not installed then generating angular scaffolding fails with:

```
/usr/local/lib/node_modules/generator-angular/node_modules/wiredep/lib/detect-dependencies.js:89
  if ($._.isString(componentConfigFile.main)) {
                                      ^
TypeError: Cannot read property 'main' of undefined
    at findMainFiles (/usr/local/lib/node_modules/generator-angular/node_modules/wiredep/lib/detect-dependencies.js:89:39)
   [...]
```

which means: (ref: https://github.com/yeoman/generator-angular/issues/635 -- stephenplusplus' closing comment) 

It should run "bower install" automatically for you. Something funky must have happened that first time during scaffolding. If it happens in the future, this error means "I'm trying to work with your Bower packages, but you gots none installed!"

I spent hours googling this error, cleaning and re-installing everything from node to xcode -- there have been a lot of people looking for this answer 

when I finally found this note, it was the work of moments to: npm install -g bower

thanks for your time
al;
