### PR TITLE
Adding install and troubleshooting instructions

### DIFF
--- a/app/codelab/setup.md
+++ b/app/codelab/setup.md
@@ -42,17 +42,14 @@ If you don't have Git, grab the installers from the [git website](http://git-scm
 Once you’ve got Node installed, install the Yeoman toolset:
 
 ```sh
-$ npm install --global yo
-$ npm install --global bower
-$ npm install --global grunt
-$ npm install --global grunt-cli
+$ npm install --global yo bower grunt-cli
 ```
 
 <div class="note important">
 
   <h2>Errors?</h2>
 
-  <p>If you see permission or access errors, do not use <code>sudo</code> as a work-around. <br>
+  <p>If you see permission or access errors, such as permission (`EPERM`) or access errors (`EACCESS`), do not use <code>sudo</code> as a work-around. <br>
   Consult [this page](https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo-linux.md) for a more robust solution to the permissions errors.</p>
 
 
@@ -76,7 +73,7 @@ Running the above should output three separate version numbers:
 
   <h2>Versions of the CLI tools that this codelab works with</h2>
 
-  <p>Technology changes quickly! This tutorial has been tested with <strong>Yeoman 1.2.0</strong>, <strong>Bower 1.3.5</strong>, and <strong>grunt-cli v0.1.13</strong>. If you are running into issues with a newer version, we would like to hear about it. Please open up an issue on our <a href="https://github.com/yeoman/yeoman.io/issues">tracker</a>.</p>
+  <p>Technology changes quickly! This tutorial has been tested with <strong>Yeoman 1.3.2</strong>, <strong>Bower 1.3.12</strong>, and <strong>grunt-cli v0.1.13</strong>. If you are running into issues with a newer version, we would like to hear about it. Please open up an issue on our <a href="https://github.com/yeoman/yeoman.io/issues">tracker</a>.</p>
 
 </div>
 


### PR DESCRIPTION
The yo install script (v1.3.2) does not install grunt/grunt-cli/bower. New users will need the additional instructions.
The recommendation to use 'sudo' as a workaround for permissions and access errors is not fool-proof, as it can break the scaffolding 'npm install' instruction.
Instead, changing the 'node-module' directory to the user's home directory, as detailed in the linked guide, will address the permissions issues.
