### PR TITLE
`.jshintrc`: remove deprecated options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,7 +12,5 @@
   "noarg": true,
   "quotmark": "single",
   "undef": true,
-  "strict": false,
-  "trailing": true,
-  "smarttabs": true
+  "strict": false
 }


### PR DESCRIPTION
The `smarttabs` and `trailing` JSHint options are deprecated since JSHint v2.5.
