### PR TITLE
Fix markdown formatted link inside inline html

### DIFF
--- a/app/codelab/setup.md
+++ b/app/codelab/setup.md
@@ -50,7 +50,7 @@ $ npm install --global yo bower grunt-cli
   <h2>Errors?</h2>
 
   <p>If you see permission or access errors, such as permission (`EPERM`) or access errors (`EACCESS`), do not use <code>sudo</code> as a work-around. <br>
-  Consult [this page](https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md) for a more robust solution to the permissions errors.</p>
+  Consult <a href="https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md">this page</a> for a more robust solution to the permissions errors.</p>
 
 
 </div>


### PR DESCRIPTION
The `/codelab/setup.md` file contained a markdown-flavored link inside of embedded html, which resulted in this: 
![screenshot 2014-11-04 20 23 28](https://cloud.githubusercontent.com/assets/6025224/4906441/eb7f7662-6458-11e4-8eb0-5aab157c8cb9.png)

From http://daringfireball.net/projects/markdown/syntax#html:

> Note that Markdown formatting syntax is not processed within block-level HTML tags. E.g., you can’t use Markdown-style emphasis inside an HTML block.
