### PR TITLE
remove $ from commands

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -690,6 +690,11 @@ code.prettyprint {
   border-right: none;
 }
 
+pre > code.language-sh:before {
+  content: '$';
+  margin-right: 5px;
+}
+
 /* Specify class=linenums on a pre to get line numbering */
 ol.linenums { margin-top: 0; margin-bottom: 0; color: #AEAEAE; } /* IE indents via margin-left */
 li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8 { list-style-type: none }

--- a/app/codelab/install-generators.md
+++ b/app/codelab/install-generators.md
@@ -17,7 +17,7 @@ You can install Yeoman generators using the [npm](https://www.npmjs.org) command
 Install [generator-angular](https://www.npmjs.org/package/generator-angular) using this command:
 
 ```sh
-$ npm install --global generator-angular@0.9.2
+npm install --global generator-angular@0.9.2
 ```
 
 This will start to install the Node packages required for the generator. Using `@0.9.2` will request a specific version of the generator.
@@ -29,7 +29,7 @@ This will start to install the Node packages required for the generator. Using `
   <p>If you see permission or access errors, you will need to install the generator using <code>sudo</code>, like so:</p>
 
 <pre>
-$ sudo npm install --global generator-angular@0.9.2
+<code class="language-sh">sudo npm install --global generator-angular@0.9.2</code>
 </pre>
 
 </div>

--- a/app/codelab/install-packages.md
+++ b/app/codelab/install-packages.md
@@ -19,7 +19,7 @@ Let’s add some order to our list and make it sortable. For this we’re going 
 We can check what packages we have already installed by running this command from within the myTodo project directory created earlier:
 
 ```sh
-$ bower list
+bower list
 ```
 
 ![](/assets/img/codelab/image_22.png)
@@ -31,7 +31,7 @@ You should see that you already have packages for angular-cookies, angular-resou
 To verify that there are AngularUI packages available, use Bower to search for "angular-ui-sortable":
 
 ```sh
-$ bower search angular-ui-sortable
+bower search angular-ui-sortable
 ```
 
 There is one result for "angular-ui-sortable" so let’s install it along with [jQuery UI](http://jqueryui.com/) as we already have jQuery installed. To save you from searching, the package name for jQuery UI is "jquery-ui".
@@ -41,8 +41,10 @@ There is one result for "angular-ui-sortable" so let’s install it along with [
 Use Bower to install both "angular-ui-sortable" and "jquery-ui":
 
 ```sh
-$ bower install --save angular-ui-sortable
-$ bower install --save jquery-ui
+bower install --save angular-ui-sortable
+```
+```sh
+bower install --save jquery-ui
 ```
 
 The `--save` option updates the ***bower.json*** file with dependencies on angular-ui-sortable and jquery-ui. This will save you from having to manually add it to *bower.json* yourself.
@@ -54,7 +56,7 @@ The `--save` option updates the ***bower.json*** file with dependencies on angul
   <p>If you have multiple packages that you want to install, you can do it in one line:</p>
 
 <pre>
-$ bower install --save angular-ui-sortable jquery-ui
+<code class="language-sh">bower install --save angular-ui-sortable jquery-ui</code>
 </pre>
 
 </div>

--- a/app/codelab/local-storage.md
+++ b/app/codelab/local-storage.md
@@ -8,7 +8,7 @@ sidebar: sidebars/codelab.html
 
 # Step 10: Make Todos persistent with local storage
 
-Let’s revisit the issue of items not persisting when the browser refreshes. 
+Let’s revisit the issue of items not persisting when the browser refreshes.
 
 <div class="note tip">
   If you had no issues with Step 7 and you're short on time, you can skip to the <a href="keep-going.html">codelab wrapup</a>.
@@ -16,19 +16,19 @@ Let’s revisit the issue of items not persisting when the browser refreshes.
 
 ## Install Bower package
 
-To easily achieve this we can use another Angular module called "[angular-local-storage](http://gregpike.net/demos/angular-local-storage/demo.html)" that will allow us to quickly implement [local storage](http://diveintohtml5.info/storage.html). Again, Bower comes to the rescue. 
+To easily achieve this we can use another Angular module called "[angular-local-storage](http://gregpike.net/demos/angular-local-storage/demo.html)" that will allow us to quickly implement [local storage](http://diveintohtml5.info/storage.html). Again, Bower comes to the rescue.
 
 Run the following command:
 
 ```sh
-$ bower install --save angular-local-storage
+bower install --save angular-local-storage
 ```
 
 ![](/assets/img/codelab/image_29.png)
 
 ## Add local storage
 
-Similar to how we added jQueryUI and AngularUI Sortable in [Step 7](install-packages.html#implement) to make todos sortable, we need to add a reference to the *angular-local-storage.js* file in *index.html*. 
+Similar to how we added jQueryUI and AngularUI Sortable in [Step 7](install-packages.html#implement) to make todos sortable, we need to add a reference to the *angular-local-storage.js* file in *index.html*.
 
 Since we're using *bower.json* to keep track of our modules, <span class="keyboard">Ctrl</span>+<span class="keyboard">C</span> to exit the current command line process, then re-run `grunt serve` to get some automated magic in your *index.html*.
 

--- a/app/codelab/prepare-production.md
+++ b/app/codelab/prepare-production.md
@@ -28,7 +28,7 @@ To create a production version of our application, we’ll want to:
 Phew! Amazingly we can achieve all of this just by running:
 
 ```sh
-$ grunt
+grunt
 ```
 
 This command will go through the Grunt tasks and configuration Yeoman has set up for you in *Gruntfile.js* and create a version of your app we can ship. Give it a minute and you should be presented with a completed build and a report of how long the build took to complete and where time was spent:
@@ -42,7 +42,7 @@ Your lean, production-ready application is now available in a ***dist*** folder 
 Want to preview your production app locally? That’s just another simple grunt command:
 
 ```sh
-$ grunt serve:dist
+grunt serve:dist
 ```
 
 It will build your project and launch a local web server. Yo Hero!

--- a/app/codelab/preview-inbrowser.md
+++ b/app/codelab/preview-inbrowser.md
@@ -15,7 +15,7 @@ To preview your web app in your favourite web browser, you don't have to do anyt
 Run a Grunt task to create a local, Node-based http server on [localhost:9000](http://localhost:9000) (or [127.0.0.1:9000](http://127.0.0.1:9000) for some configurations) by typing:
 
 ```sh
-$ grunt serve
+grunt serve
 ```
 
 Your web browser will launch your newly scaffolded application in a new tab:

--- a/app/codelab/scaffold-app.md
+++ b/app/codelab/scaffold-app.md
@@ -15,7 +15,7 @@ We've used the word "scaffold" a few times but you might not know what that mean
 Create a ***mytodo*** folder for all your codelab work:
 
 ```sh
-$ mkdir mytodo && cd mytodo
+mkdir mytodo && cd mytodo
 ```
 
 This folder is where the generator will place your scaffolded project files.
@@ -29,7 +29,7 @@ As an added bonus, the Angular generator will dynamically use the name of your f
 Run `yo` again to see your generators:
 
 ```sh
-$ yo
+yo
 ```
 
 If you have a few generators installed, you'll be able to interactively choose from them. Highlight **Run the Angular generator**. Hit **enter** to run the generator.
@@ -43,7 +43,7 @@ If you have a few generators installed, you'll be able to interactively choose f
   <p>As you become more familiar with <code>yo</code>, you can run generators directly without the use of the interactive menu, like so:</p>
 
 <pre>
-$ yo angular
+<code class="language-sh">yo angular</code>
 </pre>
 
 </div>

--- a/app/codelab/setup.md
+++ b/app/codelab/setup.md
@@ -19,13 +19,13 @@ Most of your interactions with Yeoman will be through the command line. Run comm
 Before installing Yeoman, you will need the following:
 
 * Node.js v0.10.x+
-* npm (which comes bundled with Node) v1.4.3+
+* npm (which comes bundled with Node) v2.1.0+
 * git
 
 You can check if you have Node and npm installed by typing:
 
 ```sh
-$ node --version && npm --version
+node --version && npm --version
 ```
 
 If you need to upgrade or install Node, the easiest way is to use an installer for your platform. Download the *.msi* for Windows or *.pkg* for Mac from the [NodeJS website](http://nodejs.org/download/).
@@ -33,7 +33,7 @@ If you need to upgrade or install Node, the easiest way is to use an installer f
 You can check if you have Git installed by typing:
 
 ```sh
-$ git --version
+git --version
 ```
 If you don't have Git, grab the installers from the [git website](http://git-scm.com/).
 
@@ -42,7 +42,7 @@ If you don't have Git, grab the installers from the [git website](http://git-scm
 Once you’ve got Node installed, install the Yeoman toolset:
 
 ```sh
-$ npm install --global yo bower grunt-cli
+npm install --global yo bower grunt-cli
 ```
 
 <div class="note important">
@@ -60,7 +60,7 @@ $ npm install --global yo bower grunt-cli
 It is a good idea to check that everything is installed as expected by running commonly used Yeoman commands like `yo`, `bower`, and `grunt` with the `--version` flag as follows:
 
 ```sh
-$ yo --version && bower --version && grunt --version
+yo --version && bower --version && grunt --version
 ```
 
 Running the above should output three separate version numbers:

--- a/app/codelab/write-unit-tests.md
+++ b/app/codelab/write-unit-tests.md
@@ -15,7 +15,7 @@ For those unfamiliar with [Karma](http://karma-runner.github.io), it is a JavaSc
 Let’s go back to the command line and kill our Grunt server using <span class="keyboard">Ctrl</span>+<span class="keyboard">C</span>. There is already a Grunt task scaffolded out in our ***Gruntfile.js*** for running tests. It can be run as follows:
 
 ```sh
-$ grunt test
+grunt test
 ```
 
 When you run `grunt test`, you'll see some warnings in the Yeoman console. Don’t worry, that’s to be expected right now since our tests are currently failing for two reasons. Let's fix that.


### PR DESCRIPTION
Adds the `$` in CSS so it doesn't get selected when copying commands.

Fixes #292
