### PR TITLE
fix path to fit angular-local-storage v0.1.0+

### DIFF
--- a/app/codelab/local-storage.md
+++ b/app/codelab/local-storage.md
@@ -35,7 +35,7 @@ Since we're using *bower.json* to keep track of our modules, <span class="keyboa
 At the bottom of *index.html*, this should have been added:
 
 ```html
-<script src="bower_components/angular-local-storage/angular-local-storage.js"></script>
+<script src="bower_components/angular-local-storage/dist/angular-local-storage.js"></script>
 ```
 
 Your *index.html* scripts block should now look like this:
@@ -54,7 +54,7 @@ Your *index.html* scripts block should now look like this:
 <script src="bower_components/angular-route/angular-route.js"></script>
 <script src="bower_components/jquery-ui/ui/jquery-ui.js"></script>
 <script src="bower_components/angular-ui-sortable/sortable.js"></script>
-<script src="bower_components/angular-local-storage/angular-local-storage.js"></script>
+<script src="bower_components/angular-local-storage/dist/angular-local-storage.js"></script>
 <!-- endbower -->
 <!-- endbuild -->
 ```


### PR DESCRIPTION
fixes #380. 
since v0.1.0 that angular-local-storage doesn't keep its files in root but rather in the `dist` folder.
