### PR TITLE
Break long words in description

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -741,6 +741,16 @@ li.L1,li.L3,li.L5,li.L7,li.L9 { }
   min-width: 200px;
 }
 
+.discovery-page .desc {
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+}
+
 .discovery-page .author {
   min-width: 150px;
 }


### PR DESCRIPTION
See #390

The css is working in Internet Explorer 8+, Firefox 6+, iOS 4.2, Safari 5.1+ and Chrome 13+.
