### PR TITLE
Updated getting started to install grunt-cli

### DIFF
--- a/app/learning/index.md
+++ b/app/learning/index.md
@@ -26,10 +26,10 @@ Yo is maintained by the Yeoman project and offers web application scaffolding, u
 First, you'll need to install `yo` and other required tools:
 
 ```sh
-npm install -g yo bower
+npm install -g yo bower grunt-cli
 ```
 
-*see the section about **Bower** below for more information*
+*see the sections about __Bower__ and __Grunt__ below for more information*
 
 *npm is the package manager for [Node.js](http://nodejs.org/) and comes bundled with it.*
 


### PR DESCRIPTION
The final steps of the guide tell the reader to run grunt commands, but they weren't told to install grunt. I went through this and got a bit confused why grunt wasn't working.

The codelab tutorial installs all three (ie. yo, bower and grunt-cli)
