### PR TITLE
restore previous placement of </form>

### DIFF
--- a/app/codelab/write-app.md
+++ b/app/codelab/write-app.md
@@ -88,12 +88,12 @@ Modify *main.html* by adding a `form` element in between the `<h2>` and `<p>` el
         </span>
       </div>
     </div>
+  </form>
 
     <!-- Todos list -->
     <p class="form-group" ng-repeat="todo in todos">
       <input type="text" ng-model="todo" class="form-control">
     </p>
-  </form>
 </div>
 ```
 


### PR DESCRIPTION
If the Todos list is included within the form, addTodo() is also called when the X button (added in the next step) is clicked. Closing the form after the first input row, and keeping the list of entered todos out of the form so that ng-submit is only bound to one button, ensures that addTodo is only called when "Add" is clicked.