### PR TITLE
Update testing-guidelines.md

### DIFF
--- a/app/contributing/testing-guidelines.md
+++ b/app/contributing/testing-guidelines.md
@@ -44,7 +44,7 @@ Class.exclude = function () {};
 Class.name = 'Yeoman';
 Class.prototype.find = function () {};
 
-// We'd had this test structure
+// We'd have this test structure
 describe('Class', function () {
   describe('.exclude()', function () {});
   describe('.name', function () {});


### PR DESCRIPTION
"had" made it sound like it used to be the naming convention. "have" makes it a bit clearer that it's the naming convention that should be used.