### PR TITLE
Change `defaults` to `default` in ui docs

### DIFF
--- a/app/authoring/user-interactions.md
+++ b/app/authoring/user-interactions.md
@@ -115,7 +115,7 @@ The options hash (the second argument) accepts multiple key-value pairs:
 
 - `desc` Description for the option
 - `type` Either Boolean, String or Number
-- `defaults` Default value
+- `default` Default value
 - `hide` Boolean whether to hide from help
 
 Here is an example:


### PR DESCRIPTION
Part of the documentation indicated that the option for setting defaults in this.prompt was `defaults` but experimentation showed it was actually `default`, singular.

Hope this was helpful!