### PR TITLE
updating documentation for fs.commit gotcha

### DIFF
--- a/app/authoring/file-system.md
+++ b/app/authoring/file-system.md
@@ -65,7 +65,9 @@ This memory file system is shared between all [composed generators](/authoring/c
 
 ## File utilities
 
-Generators expose every file methods on `this.fs`. This object is an instance of [mem-fs editor](https://github.com/sboudrias/mem-fs-editor) - make sure to check the [module documentation](https://github.com/sboudrias/mem-fs-editor) for every methods available.
+Generators expose all file methods on `this.fs`, which is an instance of [mem-fs editor](https://github.com/sboudrias/mem-fs-editor) - make sure to check the [module documentation](https://github.com/sboudrias/mem-fs-editor) for all available methods.
+
+It is worth noting that although `this.fs` exposes `commit`, Yeoman doesn't support calling this method.  Yeoman calls this internally after the conflicts stage of the run loop.
 
 ### Example: Copying a template file
 

--- a/app/authoring/file-system.md
+++ b/app/authoring/file-system.md
@@ -67,7 +67,7 @@ This memory file system is shared between all [composed generators](/authoring/c
 
 Generators expose all file methods on `this.fs`, which is an instance of [mem-fs editor](https://github.com/sboudrias/mem-fs-editor) - make sure to check the [module documentation](https://github.com/sboudrias/mem-fs-editor) for all available methods.
 
-It is worth noting that although `this.fs` exposes `commit`, Yeoman doesn't support calling this method.  Yeoman calls this internally after the conflicts stage of the run loop.
+It is worth noting that although `this.fs` exposes `commit`, you should not call it in your generator.  Yeoman calls this internally after the conflicts stage of the run loop.
 
 ### Example: Copying a template file
 


### PR DESCRIPTION
This commit is in regards to [this yeoman generator issue](https://github.com/yeoman/generator/issues/764#issuecomment-74595150)

I am not confident in the wording mostly because I would like it to say:

"fs.commit should only be used in this circumstance"

However, I don't understand in what circumstance it should be used.  That is why I just said its use was unsupported, which is ambiguous.

Also, I wasn't able to figure out how to build yeoman.io locally.  On the 'bundler install' step I received [this output](https://gist.github.com/olsonpm/50c25bf2ebfa32777fe9).  I won't worry about it due to this commit being documentation only.