### PR TITLE
Explicitly call out generator code location

### DIFF
--- a/app/authoring/index.md
+++ b/app/authoring/index.md
@@ -85,7 +85,7 @@ The previous example can be written as follows:
 
 ## Extending generator
 
-Once you have this structure in place, it's time to write the actual generator.
+Once you have this structure in place, it's time to write the actual generator in `app/index.js`.
 
 Yeoman offers base generators which you can extend to implement your own behavior. These base generators will add most of the functionality you'd expect to ease your task.
 


### PR DESCRIPTION
While reading this page for the first time:

http://yeoman.io/authoring/

It took me a moment to figure out where to put the supplied generator code. This change explicitly references the file (`app/index.js`) that can contain the code.

I hope this will save someone else a few minutes of confusion when they write their first generator.

