### PR TITLE
Fixing typo.

### DIFF
--- a/app/authoring/file-system.md
+++ b/app/authoring/file-system.md
@@ -97,7 +97,7 @@ generators.Base.extend({
 });
 ```
 
-Once the generator is done running, `public/index.html` will contains:
+Once the generator is done running, `public/index.html` will contain:
 
 ```html
 <html>


### PR DESCRIPTION
Updating 'contains' to 'contain' as it makes more sense in the current context.