### PR TITLE
removed version from install

### DIFF
--- a/app/codelab/install-generators.md
+++ b/app/codelab/install-generators.md
@@ -17,7 +17,7 @@ You can install Yeoman generators using the [npm](https://www.npmjs.com/) comman
 Install [generator-angular](https://www.npmjs.com/package/generator-angular) using this command:
 
 ```sh
-npm install --global generator-angular@0.9.2
+npm install --global generator-angular
 ```
 
 This will start to install the Node packages required for the generator. Using `@0.9.2` will request a specific version of the generator.


### PR DESCRIPTION
This caused issues with me such as this specific one:

https://github.com/stephenplusplus/grunt-wiredep/issues/100

The version on this page is out of date and things have changed.. Why include the version at all?