### PR TITLE
Reword and clarify prompt store property

### DIFF
--- a/app/authoring/user-interactions.md
+++ b/app/authoring/user-interactions.md
@@ -43,7 +43,7 @@ Note here that we use the [`prompting` queue](/authoring/running-context.html) t
 
 A user may give the same input to certain questions every time he runs your generator. For these questions, you probably want to remember what the user answered previously and use that answer as the new `default`.
 
-Yeoman extends the Inquirer.js API by adding a `store` property to question objects. This property allow you to specify that from now on you want to use the answer as the default value. This can be done as follows:
+Yeoman extends the Inquirer.js API by adding a `store` property to question objects. This property will allow you to specify that the user entered answer should be used as the default answer in the future. This can be done as follows:
 
 ```js
 this.prompt({

--- a/app/authoring/user-interactions.md
+++ b/app/authoring/user-interactions.md
@@ -43,7 +43,7 @@ Note here that we use the [`prompting` queue](/authoring/running-context.html) t
 
 A user may give the same input to certain questions every time he runs your generator. For these questions, you probably want to remember what the user answered previously and use that answer as the new `default`.
 
-Yeoman extends the Inquirer.js API by adding a `store` property to question objects. This property will allow you to specify that the user entered answer should be used as the default answer in the future. This can be done as follows:
+Yeoman extends the Inquirer.js API by adding a `store` property to question objects. This property allows you to specify that the user provided answer should be used as the default answer in the future. This can be done as follows:
 
 ```js
 this.prompt({


### PR DESCRIPTION
The sentence describing the use of the `store` property was grammatically incorrect and unclear. Reworded the sentence to improve readability and to clarify how the property behaves.