### PR TITLE
Fix notes about permission errors

### DIFF
--- a/app/codelab/install-generators.md
+++ b/app/codelab/install-generators.md
@@ -26,11 +26,7 @@ This will start to install the Node packages required for the generator. Using `
 
   <h2>Errors?</h2>
 
-  <p>If you see permission or access errors, you will need to install the generator using <code>sudo</code>, like so:</p>
-
-<pre>
-<code class="language-sh">sudo npm install --global generator-angular@0.11.1</code>
-</pre>
+  <p>If you see permission or access errors, such as <code>EPERM</code> or <code>EACCESS</code>, do not use <code>sudo</code> as a work-around. You can consult <a href="https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md">this guide</a> for a more robust solution.</p>
 
 </div>
 

--- a/app/codelab/setup.md
+++ b/app/codelab/setup.md
@@ -55,9 +55,7 @@ npm install --global yo bower grunt-cli
 
   <h2>Errors?</h2>
 
-  <p>If you see permission or access errors, such as permission (`EPERM`) or access errors (`EACCESS`), do not use <code>sudo</code> as a work-around. <br>
-  Consult <a href="https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md">this page</a> for a more robust solution to the permissions errors.</p>
-
+  <p>If you see permission or access errors, such as <code>EPERM</code> or <code>EACCESS</code>, do not use <code>sudo</code> as a work-around. You can consult <a href="https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md">this guide</a> for a more robust solution.</p>
 
 </div>
 


### PR DESCRIPTION
Don't suggest `sudo` and instead directly link to Sindre's guide. Also cleanup the wording a little.

Fix https://github.com/yeoman/yeoman.io/issues/470