### PR TITLE
Remove two outdated talks on the homepage

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -71,10 +71,6 @@ title: The web's scaffolding tool for modern webapps
         <p>
           All three of these tools are developed and maintained separately, but work well together as part of our prescribed workflow for keeping you effective.
         </p>
-
-        <h3>More on Tooling</h3>
-
-        <p>To learn more about the current developer tooling eco-system, you may be interested in watching Paul's talk on <a href="https://www.youtube.com/watch?feature=player_embedded&v=Mk-tFn2Ix6g">"Better Web App Development Through Tooling"</a> or Addy's Yeoman session on <a href="https://www.youtube.com/watch?feature=player_embedded&v=Hl1sp9axHEY">Google Developers Live.</a></p>
       </section><!-- /.content-chunk -->
 
       <section class="content-chunk section-team">


### PR DESCRIPTION
Remove two outdated talks/screencasts from the home page. Both are not relevant to the current yeoman workflow anyways.

Fix #414 