### PR TITLE
Blacklist repository is not a real yeoman-generator

### DIFF
--- a/app/blacklist.json
+++ b/app/blacklist.json
@@ -10,5 +10,6 @@
   "generator-mtb-app",
   "generator-meteor-abtx",
   "generator-angular-sparkstack",
-  "generator-ayrofast"
+  "generator-ayrofast",
+  "generator-react-fullstack"
 ]


### PR DESCRIPTION
https://www.npmjs.com/package/generator-react-fullstack
If you check the code source the repository use yeoman only to copy
files of repository https://github.com/kriasoft/react-starter-kit

No choice in prompt, no repository on Github.
Strange publish @koistya