### PR TITLE
Upgrade grunt-livestyle and disable css background-image watching

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,7 @@ module.exports = function (grunt) {
       watchHtml: true,
 
       // Watch CSS bakground images and livereload on changes
-      watchCssImages: true,
+      watchCssImages: false,
 
       // Run each image through the image processing pipeline exposed by express-processimage
       // Allows you to resize, recompress, change image format, rasterize SVG and much more

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt-contrib-csslint": "^0.4.0",
     "grunt-contrib-jshint": "^0.11.1",
     "grunt-jekyll": "^0.4.2",
-    "grunt-livestyle": "^1.5.1",
+    "grunt-livestyle": "^1.6.0",
     "grunt-reduce": "^2.0.0",
     "jshint-stylish": "^1.0.0",
     "load-grunt-tasks": "^3.1.0",


### PR DESCRIPTION
Fixes this error:
```
Uncaught RangeError: Maximum call stack size exceeded livestyle-client.js:60
```

also opens browser when server is started