### PR TITLE
Update grunt-reduce to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-contrib-jshint": "^0.11.1",
     "grunt-jekyll": "^0.4.2",
     "grunt-livestyle": "^1.6.0",
-    "grunt-reduce": "^2.0.0",
+    "grunt-reduce": "^2.1.0",
     "jshint-stylish": "^1.0.0",
     "load-grunt-tasks": "^3.1.0",
     "svgo": "^0.4.5",


### PR DESCRIPTION
This should take care of some of those errors in the travis build.

- Updated image optimization binaries
- Updated autoprefixer implementation