### PR TITLE
use current version of yeoman-generator

### DIFF
--- a/app/authoring/index.md
+++ b/app/authoring/index.md
@@ -36,7 +36,7 @@ Once inside your generator folder, create a `package.json` file. This file is a 
   ],
   "keywords": ["yeoman-generator"],
   "dependencies": {
-    "yeoman-generator": "^0.17.3"
+    "yeoman-generator": "^0.20.2"
   }
 }
 ```


### PR DESCRIPTION
Later in the "Authoring" guide, [there are examples which refer to APIs not present in 0.17.3](http://stackoverflow.com/questions/31124053/yeoman-generator-throws-the-error-object-has-no-method-templatepath)., so the existing `package.json` doesn't work.