### PR TITLE
Add description to priority: default

### DIFF
--- a/app/authoring/running-context.md
+++ b/app/authoring/running-context.md
@@ -81,7 +81,7 @@ The available priorities are (in order):
 1. `initializing` - Your initialization methods (checking current project state, getting configs, etc)
 2. `prompting` - Where you prompt users for options (where you'd call `this.prompt()`)
 3. `configuring` - Saving configurations and configure the project (creating `.editorconfig` files and other metadata files)
-4. `default`
+4. `default` - If the method name doesn't match a priority, it will be pushed to this group.
 5. `writing` - Where you write the generator specific files (routes, controllers, etc)
 6. `conflicts` - Where conflicts are handled (used internally)
 7. `install` - Where installation are run (npm, bower)


### PR DESCRIPTION
While I want to create a generator first time,
I roll to the bottom, but can't figure out what does `default` mean.
I thought adding this piece of simple description will be much more friendly to whom is new to yeoman.