### PR TITLE
Fix: sort by installs

### DIFF
--- a/app/assets/js/generator.js
+++ b/app/assets/js/generator.js
@@ -66,7 +66,7 @@
           valueNames: [
             'name',
             'stars',
-            'downloads'
+            'installs'
           ]
         });
 

--- a/app/generators/index.html
+++ b/app/generators/index.html
@@ -21,7 +21,7 @@ class: discovery-page
         <tr>
           <th class="sort" data-sort="name">Generator</th>
           <th class="sort" data-sort="stars">Stars</th>
-          <th class="sort" data-sort="dls">Installs</th>
+          <th class="sort" data-sort="installs">Installs</th>
         </tr>
       </thead>
       <tbody class="list">


### PR DESCRIPTION
The "sorting by installs" is not working.
http://yeoman.io/generators/

I corrected the attribute to fix it.