### PR TITLE
make name and description more prominent

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -758,15 +758,23 @@ li.L1,li.L3,li.L5,li.L7,li.L9 { }
   font-size: small;
   margin-left: 20px;
 }
-.discovery-page .updated {
-  font-size: smaller;
-  margin-left: 30px;
+
+.discovery-page span.metadata {
+  font-size: 0.6em;
+  float: right;
+}
+.discovery-page span.metadata span {
+  display: inline-block;
+  margin-left: 50px;
 }
 
-.discovery-page td.stars,
-.discovery-page td.installs {
-  width: 75px;
-  text-align: center;
+.discovery-page th.metadata {
+  font-size: 0.9em;
+  text-align: right;
+  width: 85px;
+}
+.discovery-page th.last-updated {
+  width: 125px;
 }
 
 .discovery-page input.search {

--- a/app/assets/js/generator.js
+++ b/app/assets/js/generator.js
@@ -66,6 +66,7 @@
           valueNames: [
             'name',
             'stars',
+            'updated',
             'installs'
           ]
         });

--- a/app/generators/index.html
+++ b/app/generators/index.html
@@ -20,14 +20,15 @@ class: discovery-page
       <thead>
         <tr>
           <th class="sort" data-sort="name">Generator</th>
-          <th class="sort" data-sort="stars">Stars</th>
-          <th class="sort" data-sort="installs">Installs</th>
+          <th class="sort metadata last-updated" data-sort="updated">Last Updated</th>
+          <th class="sort metadata" data-sort="stars">Stars</th>
+          <th class="sort metadata" data-sort="installs">Installs</th>
         </tr>
       </thead>
       <tbody class="list">
         <% _.each(modules, function (el) { %>
           <tr class="<%= el.official %>">
-            <td class="name">
+            <td class="name" colspan="4">
               <span class="name-info">
                 <span class="name-website">
                   <% if (el.site) { %>
@@ -44,19 +45,19 @@ class: discovery-page
                   <% } else { %>
                     <%- el.owner.name %>
                   <% } %>
-                  <% if (el.updated) { %>
-                    <span class="updated">
-                      Last updated: <%- el.updated %> ago
-                    </span>
-                  <% } %>
                 </span>
                 <% } %>
+                <span class="metadata">
+                  <% if (el.updated) { %>
+                      <span>Last updated: <%- el.updated %> ago</span>
+                  <% } %>
+                  <span><%- el.stars %></span>
+                  <span><%- el.downloads %></span>
+                </span>
               </span>
               <br>
               <span class="desc"><%- el.description %></span>
             </td>
-            <td class="stars"><%- el.stars %></td>
-            <td class="installs"><%- el.downloads %></td>
           </tr>
         <% }); %>
       </tbody>


### PR DESCRIPTION
Make installs, downloads less prominent (smaller).

Adds a sort on the last updated field. Also fixes a bug around showing the last updated field (wouldn't show if the author didn't have a name displayed)

Description spans the whole row now.

Mobile styles need some loving.

![search](https://cloud.githubusercontent.com/assets/127535/10091270/e49b0ebc-62ed-11e5-9718-a7cea480423c.png)
