### PR TITLE
Fix Markdown link

### DIFF
--- a/app/learning/index.md
+++ b/app/learning/index.md
@@ -39,8 +39,7 @@ Then install the needed generator(s). Generators are npm packages named `generat
 npm install -g generator-webapp
 ```
 
-New Node and npm users might run into permissions issues. These issues show up in the form of `EACCESS` errors during installation. Refer to the [npm guide to fix permissions]
-(https://docs.npmjs.com/getting-started/fixing-npm-permissions) if this happens to you.
+New Node and npm users might run into permissions issues. These issues show up in the form of `EACCESS` errors during installation. Refer to the [npm guide to fix permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) if this happens to you.
 
 *npm is the package manager for [Node.js](https://nodejs.org/) and comes bundled with it.*
 


### PR DESCRIPTION
Removes a space so that the link is properly displayed in the generated docs.