### PR TITLE
Add rewrite rule for API docs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,8 @@ module.exports = function (grunt) {
         '404.html',
         'migrate.html',
         '*/**/*.html',
-        'CNAME'
+        'CNAME',
+        '_redirects'
       ],
 
       browsers: [

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ atom_path: /blog/atom.xml
 
 source: app
 destination: .tmp
+include:
+- _redirects
 
 # _config.build.yml sets future and show_drafts to false on `grunt build`
 future: true

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,0 +1,2 @@
+
+/generator/*  http://yeoman.github.io/generator/:splat   200

--- a/app/_redirects
+++ b/app/_redirects
@@ -1,2 +1,2 @@
 
-/generator/*  http://yeoman.github.io/generator/:splat   200
+/generator/*  http://yeoman.github.io/generator   302!


### PR DESCRIPTION
This fixes the 404 error which appears at the url http://yeoman.io/generator after moving the hosting to netlify.

Right now it redirects to http://yeoman.github.io/generator 

It would be possible to use a [rewrite](https://www.netlify.com/docs/redirects/#rewrites-and-proxying) instead if we could set up a base href in the generated docs. 

This needs further investigation. Going to merge this to eliminate the dead link.

