### PR TITLE
[doc website] Add a nice search experience

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -33,4 +33,7 @@
 
 
   <link href="/blog/atom.xml" type="application/atom+xml" rel="alternate" title="Yeoman Blog Atom Feed">
+
+  <link href="/assets/css/search.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 </head>

--- a/app/_layouts/base.html
+++ b/app/_layouts/base.html
@@ -18,5 +18,11 @@
     {% include foot.html %}
     {% endif %}
   </div>
+
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
+    apiKey: '9df58ffd00f1dfb0eb2c5c6eaff8d971',
+    indexName: 'yeoman',
+    inputSelector: '#q'
+  })" async></script>
 </body>
 </html>

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -9,7 +9,9 @@ markdown: 0
 
   <div class="container clearfix{% if page.sidebar %} has-sidebar{% endif %}">
     {% if page.sidebar %}
+
       <nav class="context-nav">
+        <input id="q" placeholder="Search the doc" />
         {% capture sidebar %}{% include {{ page.sidebar }} %}{% endcapture %}
         {% if sidebarHTML %}
           {{ sidebar }}

--- a/app/index.html
+++ b/app/index.html
@@ -24,6 +24,9 @@ title: The web's scaffolding tool for modern webapps
         <pre>npm install -g yo</pre>
       </section><!-- /.one-line-install -->
 
+      <section>
+        <input id="q" placeholder="Search the doc" />
+      </section>
       <section class="content-chunk section-tools">
         <h1>What's Yeoman?</h1>
 


### PR DESCRIPTION
👋 team,

TL;DR: Add a learn-as-you-type search experience to the documentation

I'm working at Algolia on the a project called [DocSearch](https://community.algolia.com/docsearch/) which goal is to enhance documentation websites with exhaustive, fast and relevant search. You might have seen DocSearch live already on websites like [react](https://reactjs.org/), [Bootstrap](https://getbootstrap.com/), [Brew](https://brew.sh/) or [jQuery](https://jquery.com/).

I have created [a preview of this PR](https://docsearch-yeoman.netlify.com/) and what DocSearch on the yeoman website could will look like here. Feel free to try it and let us know what you think. Please note the learn-as-you-type experience and the typo tolerance:

[![demo of DocSearch + yeoman](https://cl.ly/4136ae7231f4/download/Screen%20Recording%202019-04-24%20at%2002.54%20PM.gif)](https://docsearch-yeoman.netlify.com/)

The way DocSearch works is by crawling your content, pushing the results into an Algolia index, and then requesting this index directly from the website front-end through JavaScript.

We'll take care of crawling your website and populating the Algolia index with the latest changes every 24h for you. You don't need to change anything to your deployment process. The only thing you need to add are the following CSS and JS snippets that will bind the dropdown to your searchbox.

We built DocSearch with the idea of giving back to the Open-Source community. This is why your [crawling configuration](https://github.com/algolia/docsearch-configs/blob/master/configs/python-yeoman.json) is available on GitHub if you want to change it. We also have our own [documentation](https://community.algolia.com/docsearch/documentation/) to help you tweak the dropdown to your needs. You'll also have access to *analytics on the most searched terms* or those with *no results*. All of this is of course *entirely free*.