### PR TITLE
Remove Google

### DIFF
--- a/app/_includes/foot.html
+++ b/app/_includes/foot.html
@@ -69,7 +69,7 @@
 </footer>
 <!-- /.footer-links -->
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@2.1.0/dist/jquery.min.js"></script>
 {% if page.title == 'Generators' %}
 <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@2.7.1"></script>
 <script src="https://cdn.jsdelivr.net/npm/timeago.js@3.0.2/dist/timeago.min.js"></script>
@@ -201,13 +201,5 @@
     },
     this
   );
-  var _gaq = [
-    ["_setAccount", "UA-32956520-1"],
-    ["_setDomainName", ".yeoman.io"],
-    ["_trackPageview"],
-    ["_trackPageLoadTime"]
-  ];
-  $script("https://www.google-analytics.com/ga.js");
-  $script("https://apis.google.com/js/plusone.js");
   $script("//platform.twitter.com/widgets.js");
 </script>

--- a/app/_includes/social.html
+++ b/app/_includes/social.html
@@ -3,9 +3,4 @@
   <a href="https://twitter.com/share" class="twitter-share-button" data-text="{{page.social_text||page.title}}" data-url="{{page.social_url}}">Tweet</a>
   <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
   <!--twitter-->
-
-  <!--plus-->
-  <script src="https://apis.google.com/js/plusone.js"></script><g:plus action="share"></g:plus>
-  <!--plus-->
-
 </div>

--- a/app/_posts/blog/2014-03-04-performance-optimization.md
+++ b/app/_posts/blog/2014-03-04-performance-optimization.md
@@ -230,7 +230,7 @@ The Zopfli Compression Algorithm is an open-source compression library that gene
 
 * [gulp-zopfli](https://www.npmjs.com/package/gulp-zopfli)
 
-<div class="note"><strong>Note:</strong> When Google Fonts  switched to using Zopfli fonts were ~6% smaller on average, and in some cases up to 15% smaller. According to <a href="https://plus.google.com/+IlyaGrigorik/posts/1sxencNkbNS">Ilya Grigorik</a>, for the case of Open Sans it was more than 10% smaller, translating to faster rendering and loading times. Zopfli images can however take longer to decode than JPGs so measure the metrics that matter to you when deciding whether to use WebP.</div>
+<div class="note"><strong>Note:</strong> When Google Fonts  switched to using Zopfli fonts were ~6% smaller on average, and in some cases up to 15% smaller. According to Ilya Grigorik, for the case of Open Sans it was more than 10% smaller, translating to faster rendering and loading times. Zopfli images can however take longer to decode than JPGs so measure the metrics that matter to you when deciding whether to use WebP.</div>
 
 
 ## Inline Critical path CSS

--- a/app/misc/insight.md
+++ b/app/misc/insight.md
@@ -22,13 +22,9 @@ There are a number of useful questions we can answer with good metrics:
 - What JS frameworks are people using?
 - Imagine: We just launched Yeoman v2.0 @ AwesomeConf JS 2013. Of course it was picked up by Hacker News! Pssht. But...how many new installs did we drive?
 
-Turns out, [Google Analytics](http://www.google.com/analytics/) is excellent at handling all of these cases.
-
 ## Collection Workflow
 
 ### Backend
-
-Google Analytics suits most of our needs. It was designed to allow any type of app (mobile, non-web page properties, installed apps, etc.) to send data to Analytics for processing. It works similar to the existing API, with the exception that cookies are no longer required.
 
 There are a many benefits to using Analytics instead of rolling our own collecting server on App Engine. Perhaps the biggest: not having to process data ourselves.
 
@@ -42,7 +38,7 @@ There are a many benefits to using Analytics instead of rolling our own collecti
 
 > *Note: /metrics was originally setup as an App Engine Python app before Analytics was chosen as backend. At this time, we don't need a separate server but the code is intact if/when we decide to build a dashboard for Yeoman.*
 
-This script is installed globally as an alias `_yeomaninsight` to prevent users from a.) seeing the script via auto completing "yeoman*" and b.) mitigating running the script directly.  The script is responsible for collecting, stashing, and sending usage data to Google Analytics.
+This script is installed globally as an alias `_yeomaninsight` to prevent users from a.) seeing the script via auto completing "yeoman*" and b.) mitigating running the script directly.
 
 `_yeomaninsight` is invoked by `/cli/lib/plugins/insight.py`, which creates a folder in the home directory (`~/.yeoman/insight/`) when the cli is run for the first time and prompts the user to opt-in to sending anonymous metrics.
 
@@ -123,12 +119,3 @@ Once all data is sent, `.log` is scrubbed clean of past data, although the Clien
 
     1336617026.860.421519437366
 
-###Privacy
-
-Our implementation uses Google Analytics. See their [TOS/Privacy Policy](http://www.google.com/analytics/learn/privacy.html) (e.g. Google's Privacy Policy) for more information. There are a few points worth calling out:
-
-- Recording stats are opt-out. This is determined on first-run of the CLI.
-- We eventually plan to open up the collected data to the public. Everyone will benefit!! We plan to have a metrics dashboard where folks can see the data, as collected by the tool.
-- The Client ID is generated as combination of timestamp + random_number and is in no way tied to personal data like IP address, name, location, or other personally identifiable information. Google Analytics uses this data (in aggregate) in order to differentiate users of an app. It allows us to answer the question: "# of 7 day active users".
-- Data is sent to Analytics, an aggregate collection service. There will be no way for us to see information on any one person.
-- We are not recording names of things that were created (e.g. someone's model name, file naming conventions, etc.)


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.
Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/

---

I have removed Plusone and Google+ integration, as they are both dead platforms...