### PR TITLE
Update debugging.md to match new npx options

### DIFF
--- a/app/authoring/debugging.md
+++ b/app/authoring/debugging.md
@@ -10,7 +10,7 @@ To debug a generator, you can pass Node.js debug flags by running it like this:
 
 ```sh
 # OS X / Linux / Windows
-npx --node-arg=--inspect yo <generator> [arguments]
+npx --node-options="--inspect" yo <generator> [arguments]
 ```
 
 You can then debug your generator using the Chrome Devtools or your preferred IDE. See [Node Debugging Guide](https://nodejs.org/en/docs/inspector/) for more info.


### PR DESCRIPTION
`--node-arg` was removed in npx version 7.

See https://stackoverflow.com/questions/66459448/how-do-i-use-node-arg-in-npx-npm-version-7