### PR TITLE
Update review-generated-files.md

### DIFF
--- a/app/codelab/review-generated-files.md
+++ b/app/codelab/review-generated-files.md
@@ -34,7 +34,7 @@ In *mytodo*, we have:
   <p>You can safely add a commit to save the current state by these commands.</p>
 
 <pre>
-<code class="language-sh">git add --all && git commit -m 'First commit'</code>
+<code class="language-sh">git add --all && git commit -m "First commit"</code>
 </pre>
 
 </div>


### PR DESCRIPTION
updated git command to use double quotes since single quotes don't work in windows and double quotes work everywhere.