### PR TITLE
fix: wrong cmder URL in faq.md

### DIFF
--- a/app/learning/faq.md
+++ b/app/learning/faq.md
@@ -46,7 +46,7 @@ Long-term, the project may also assist developers with creating applications usi
 
 ### <a name="what-is-CLI"></a> What is a command-line interface?
 
-A command-line interface is a means for developers to interact with a system using text commands. On Linux or OSX, this is often done using the terminal. On Windows, the command shell (`cmd.exe`) or PowerShell, but we recommend you use [`cmder`](http://cmder.net/) instead for an improved experience.
+A command-line interface is a means for developers to interact with a system using text commands. On Linux or OSX, this is often done using the terminal. On Windows, the command shell (`cmd.exe`) or PowerShell, but we recommend you use [`cmder`](https://cmder.app/) instead for an improved experience.
 
 
 ### <a name="what-is-pkg-manager"></a> What is a package manager?


### PR DESCRIPTION
Hi!

I've started to explore the yeoman ecosystem and out of curiosity clicked on the cmder URL in the FAQ, only to find myself on a shady-looking website. Therefore I'm making a minimal pull request to update this URL so that people don't get ferried into stormy waters. Easy enough of a fix.

The rest of the links are okay - checked to make sure.

Cheers,
JP