### PR TITLE
feat: suggest npm scripts over Grunt or Gulp in first learning flow

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -53,7 +53,7 @@ title: The web's scaffolding tool for modern webapps
         <h2>Tools</h2>
 
         <p>
-          The Yeoman workflow comprises three types of tools for improving your productivity and satisfaction when building a web app: the scaffolding tool (yo), the build tool (Gulp, Grunt etc) and the package manager (like npm and Bower).
+          The Yeoman workflow comprises three types of tools for improving your productivity and satisfaction when building a web app: the scaffolding tool (yo), the build tool (npm scripts, Gulp, Grunt etc) and the package manager (like npm and Bower).
         </p>
 
         <ul class="basic-tools clearfix">
@@ -63,7 +63,7 @@ title: The web's scaffolding tool for modern webapps
           </li>
           <li>
             <span class="tool-logo gulp"><img src="/assets/img/gulp-logo.png" alt="Gulp, Grunt etc"></span>
-            <div class="tool-content">The <strong>Build System</strong> is used to build, preview and test your project. <a href="http://gulpjs.com">Gulp</a> and <a href="http://gruntjs.com/">Grunt</a> are two popular options.</div>
+            <div class="tool-content">The <strong>Build System</strong> is used to build, preview and test your project. [npm scripts](https://docs.npmjs.com/cli/using-npm/scripts) are suggested, while <a href="http://gulpjs.com">Gulp</a> and <a href="http://gruntjs.com/">Grunt</a> are available as well.</div>
           </li>
           <li>
             <span class="tool-logo npm"><img src="/assets/img/npm-logo.png" alt="npm, Yarn, etc"></span>

--- a/app/learning/index.md
+++ b/app/learning/index.md
@@ -62,7 +62,7 @@ Most generators will ask a series of questions to customize the new project. To 
 yo webapp --help
 ```
 
-A lot of generators rely on build systems (like [Grunt](http://gruntjs.com/) or [Gulp](http://gulpjs.com/)), and package managers (like npm and Bower). Make sure to visit the generator's site to learn about running and maintaining the new app. Easily access a generator's home page by running:
+A lot of generators rely on build systems (like [npm scripts](https://docs.npmjs.com/cli/using-npm/scripts), [Grunt](http://gruntjs.com/), or [Gulp](http://gulpjs.com/)), and package managers (like npm and Bower). Make sure to visit the generator's site to learn about running and maintaining the new app. Easily access a generator's home page by running:
 
 ```sh
 npm home generator-webapp


### PR DESCRIPTION
## Purpose of this pull request? 

- [x] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [ ] Other, please explain:

## What changes did you make?

Fixes #416.

Suggests npm scripts in the two main places that mention Grunt and Gulp as potential build systems:

* `/` under _Tools_
* `/learning` under _Basic Scaffolding_

## Is there anything you'd like reviewers to focus on?

Is there anywhere else we'd want the phrasing to be updated? After #417 I think much of the decoupling was already done. I found the rest of the site to be pretty good at keeping things agnostic, but didn't dive too deep.